### PR TITLE
Add middleware to remove the alerts session cache after a request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+.phpunit.result.cache

--- a/src/Http/Middleware/CleanupAlertsCache.php
+++ b/src/Http/Middleware/CleanupAlertsCache.php
@@ -41,7 +41,11 @@ class CleanupAlertsCache
     public function terminate($request, $response)
     {
         $key = $this->config->get('laralerts.key');
+        $session = $request->session();
 
-        $request->session()->forget($key);
+        if ($session->has($key)) {
+            $session->forget($key);
+            $session->save();
+        }
     }
 }

--- a/src/Http/Middleware/CleanupAlertsCache.php
+++ b/src/Http/Middleware/CleanupAlertsCache.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace DarkGhostHunter\Laralerts\Http\Middleware;
+
+use Closure;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class CleanupAlertsCache
+{
+    /**
+     * Config Repository
+     *
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * Creates a new middleware instance
+     *
+     * @param Config $config
+     */
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    /** {@inheritdoc} */
+    public function handle($request, Closure $next)
+    {
+        return $next($request);
+    }
+
+    /**
+     * After the response is assembled, remove the alerts from the session cache.
+     *
+     * @param Request  $request
+     * @param Response $response
+     */
+    public function terminate($request, $response)
+    {
+        $key = $this->config->get('laralerts.key');
+
+        $request->session()->forget($key);
+    }
+}

--- a/tests/Http/Middleware/CleanupAlertsCacheTest.php
+++ b/tests/Http/Middleware/CleanupAlertsCacheTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+use DarkGhostHunter\Laralerts\Http\Middleware\CleanupAlertsCache;
+use DarkGhostHunter\Laralerts\Tests\Concerns\RegistersPackage;
+use Illuminate\Session\Middleware\StartSession;
+use Orchestra\Testbench\TestCase;
+
+class CleanupAlertsCacheTest extends TestCase
+{
+    use RegistersPackage;
+
+    /** @test */
+    public function it_should_remove_only_alerts_from_session() : void
+    {
+        // Create session with some data
+        $this->session(['one' => 'flew']);
+
+        // Register views location
+        /** @var \Illuminate\View\Factory $factory */
+        $factory = $this->app->make('view');
+        $factory->addLocation(__DIR__ . '/../../');
+
+        // Register route "test" that creates an alert in session, but with the middleware
+        // under test that cleans up the session after the response has been created.
+        $this->app->make('router')->get('test', function () {
+            alert('this is an alert');
+            return response()->view('test-view');
+        })->middleware([
+            StartSession::class,
+            CleanupAlertsCache::class,
+        ]);
+
+        // Assert response contains the alert, but the session not anymore
+        $this->get('test')
+             ->assertSeeText('this is an alert')
+             ->assertSessionMissing('_alerts')
+             ->assertSessionHas(['one' => 'flew']);
+    }
+}


### PR DESCRIPTION
I just installed Laralerts and out of the box the `_alerts` are never removed from the session, so the list just grows each request.

Maybe there is a better way, but a clean middleware class that only removes the alerts from the session is exactly what my app needs, so I figured it might come in handy for others as well.